### PR TITLE
[2024-09-12] 박지은 #78 BOJ 2206 벽 부수고 이동하기

### DIFF
--- a/박지은/2206.java
+++ b/박지은/2206.java
@@ -1,0 +1,70 @@
+// [2024-09-12] 박지은 #78 BOJ 2206 벽 부수고 이동하기
+// https://www.acmicpc.net/problem/2206
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+  public static int[][] arr;
+  public static boolean[][][] visit;
+  public static ArrayList<Xy> list = new ArrayList<>();
+  public static int N;
+  public static int M;
+  public static int[] dx = { 0, -1, 0, 1 };
+  public static int[] dy = { 1, 0, -1, 0 };
+
+
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+    N = Integer.parseInt(st.nextToken());
+    M = Integer.parseInt(st.nextToken());
+    arr = new int[N][M];
+    for(int i = 0; i < N; i++) {
+      String line = br.readLine();
+      for(int j = 0; j < M; j++) {
+        arr[i][j] = line.charAt(j) - '0';
+      }
+    }
+    int bfs = bfs();
+    System.out.println(bfs);
+  }
+
+  public static int bfs(){
+    visit = new boolean[N][M][2];
+    LinkedList<Xy> queue = new LinkedList<>();
+    queue.add(new Xy(0, 0, 1, false));
+
+    visit[0][0][0] = true;
+    while(!queue.isEmpty()){
+      Xy cur = queue.poll();
+      if(cur.x == N-1 && cur.y == M-1) return cur.count;
+      for(int i = 0 ; i < dx.length ; i++){
+        int nx = cur.x + dx[i];
+        int ny = cur.y + dy[i];
+        if(nx < 0 || nx >= N || ny < 0 || ny >= M) continue;
+        if(cur.curBreak && visit[nx][ny][1]) continue;
+        if(!cur.curBreak && visit[nx][ny][0]) continue;
+        if(cur.curBreak && arr[nx][ny] == 1) continue;
+        boolean nextBreak = cur.curBreak || arr[nx][ny] == 1;
+        queue.add(new Xy(nx, ny, cur.count+1, nextBreak));
+        visit[nx][ny][nextBreak ? 1 : 0] = true;
+      }
+    }
+    return -1;
+  }
+
+  static class Xy{
+    int x;
+    int y;
+    int count;
+    boolean curBreak;
+
+    public Xy(int x, int y, int count, boolean curBreak){
+      this.x = x;
+      this.y = y;
+      this.count = count;
+      this.curBreak = curBreak;
+    }
+  }
+}


### PR DESCRIPTION
#78 

## 문제
N×M의 행렬로 표현되는 맵이 있다. 맵에서 0은 이동할 수 있는 곳을 나타내고, 1은 이동할 수 없는 벽이 있는 곳을 나타낸다. 당신은 (1, 1)에서 (N, M)의 위치까지 이동하려 하는데, 이때 최단 경로로 이동하려 한다. 최단경로는 맵에서 가장 적은 개수의 칸을 지나는 경로를 말하는데, 이때 시작하는 칸과 끝나는 칸도 포함해서 센다.

만약에 이동하는 도중에 한 개의 벽을 부수고 이동하는 것이 좀 더 경로가 짧아진다면, 벽을 한 개 까지 부수고 이동하여도 된다.

한 칸에서 이동할 수 있는 칸은 상하좌우로 인접한 칸이다.

맵이 주어졌을 때, 최단 경로를 구해 내는 프로그램을 작성하시오.

### 입력
첫째 줄에 N(1 ≤ N ≤ 1,000), M(1 ≤ M ≤ 1,000)이 주어진다. 다음 N개의 줄에 M개의 숫자로 맵이 주어진다. (1, 1)과 (N, M)은 항상 0이라고 가정하자.

### 출력
첫째 줄에 최단 거리를 출력한다. 불가능할 때는 -1을 출력한다.

## 결과

![image](https://github.com/user-attachments/assets/cee30375-24c2-4dfd-b3f8-fcd19bdad309)

일반 bfs에서 벽을 한번 부쉈던 상황과 아직 부순적 없는 상황의 분기처리를 해주기 위해

visite를 3차원 배열을 사용하였다.

현재 부순 상황이면 visited의 마지막 index를 1에서 체크해주고

아직 부순적이 없는 상황이면 visited의 마지막 index를 0으로 체크해주었다.(늦어서 죄송합니다..)